### PR TITLE
Netint

### DIFF
--- a/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
@@ -14,6 +14,7 @@ import se.svt.oss.encore.model.output.Output
 @JsonSubTypes(
     JsonSubTypes.Type(value = AudioEncode::class, name = "AudioEncode"),
     JsonSubTypes.Type(value = SimpleAudioEncode::class, name = "SimpleAudioEncode"),
+    JsonSubTypes.Type(value = X264NetIntEncode::class, name = "X264NetIntEncode"),
     JsonSubTypes.Type(value = X264Encode::class, name = "X264Encode"),
     JsonSubTypes.Type(value = X265Encode::class, name = "X265Encode"),
     JsonSubTypes.Type(value = GenericVideoEncode::class, name = "VideoEncode"),

--- a/src/main/kotlin/se/svt/oss/encore/model/profile/X264NetIntEncode.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/X264NetIntEncode.kt
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2020 Sveriges Television AB
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.svt.oss.encore.model.profile
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import se.svt.oss.encore.model.input.DEFAULT_VIDEO_LABEL
+
+data class X264NetIntEncode(
+    override val width: Int?,
+    override val height: Int?,
+    override val twoPass: Boolean,
+    @JsonProperty("params")
+    override val ffmpegParams: LinkedHashMap<String, String> = linkedMapOf(),
+    @JsonProperty("x264-params")
+    override val codecParams: LinkedHashMap<String, String> = linkedMapOf(),
+    override val filters: List<String> = emptyList(),
+    override val audioEncode: AudioEncoder? = null,
+    override val audioEncodes: List<AudioEncoder> = emptyList(),
+    override val suffix: String,
+    override val format: String = "mp4",
+    override val inputLabel: String = DEFAULT_VIDEO_LABEL
+) : X26XEncode() {
+    override val codecParamName: String
+        get() = "x264-params"
+    override val codec: String
+        get() = "h264_ni_logan_enc"
+}

--- a/src/main/kotlin/se/svt/oss/encore/model/profile/X264NetIntEncode.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/X264NetIntEncode.kt
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2020 Sveriges Television AB
+// SPDX-FileCopyrightText: 2023 BCC Media STI
 //
 // SPDX-License-Identifier: EUPL-1.2
 


### PR DESCRIPTION
Apparently the codec string is locked on x264 codec so we need to create a custom `Encode` type.
If someone with more kotlin experience can produce more derived and less copy-paste version, please go ahead.